### PR TITLE
feat: Add support for MPS

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,7 +37,10 @@ parser.add_argument("--mcp_server", action="store_true", help="是否启用mcp�
 args = parser.parse_args()
 
 
-if torch.cuda.is_available():
+if torch.backends.mps.is_available():
+    device = "mps"
+    dtype = torch.float16
+elif torch.cuda.is_available():
     device = "cuda" 
     if torch.cuda.get_device_capability()[0] >= 8:
         dtype = torch.bfloat16


### PR DESCRIPTION
This commit adds support for Apple's Metal Performance Shaders (MPS) for GPU-accelerated computation on Apple Silicon.

The following files were modified:
- `inference.py`: The device selection logic was updated to check for MPS availability and set the appropriate `weight_dtype`.
- `app.py`: The device selection logic was updated to check for MPS availability and set the appropriate `dtype`.