### PR TITLE
fix: Correct tokenizer path loading and add MPS support

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,7 +66,7 @@ transformer_path = f"{model_path}/StableAvatar-1.3B/transformer3d-square.pt"
 config = OmegaConf.load("deepspeed_config/wan2.1/wan_civitai.yaml")
 sampler_name = "Flow"
 # clip_sample_n_frames moved to UI parameter
-tokenizer = AutoTokenizer.from_pretrained(os.path.join(pretrained_model_name_or_path, config['text_encoder_kwargs'].get('tokenizer_subpath', 'tokenizer')), )
+tokenizer = AutoTokenizer.from_pretrained(config['text_encoder_kwargs'].get('tokenizer_subpath', 'tokenizer'))
 text_encoder = WanT5EncoderModel.from_pretrained(
     os.path.join(pretrained_model_name_or_path, config['text_encoder_kwargs'].get('text_encoder_subpath', 'text_encoder')),
     additional_kwargs=OmegaConf.to_container(config['text_encoder_kwargs']),


### PR DESCRIPTION
This commit includes two main changes:

1.  A fix for a bug that caused a `HFValidationError` when loading the tokenizer. The code now loads the tokenizer directly from the Hugging Face Hub repo ID specified in the config file.

2.  Support for Apple's Metal Performance Shaders (MPS) for GPU-accelerated computation on Apple Silicon. The device selection logic in `inference.py` and `app.py` has been updated to prioritize MPS when available.