### PR TITLE
fix: Correct dtype conversion for MPS

### DIFF
--- a/app.py
+++ b/app.py
@@ -167,7 +167,7 @@ def generate(
     # Clear any existing device placements
     if GPU_memory_mode == "Normal":
         # For Normal mode, ensure all components are on GPU with correct dtype
-        pipeline.to(device=device)
+        pipeline.to(device=device, dtype=dtype)
         
         # pipeline.vae = pipeline.vae.to(device=device, dtype=dtype)
         # pipeline.text_encoder = pipeline.text_encoder.to(device=device, dtype=dtype)


### PR DESCRIPTION
When running on an MPS device, a `RuntimeError` would occur due to a data type mismatch between the input and the model weights (`MPSHalfType` vs `MPSFloatType`).

This was caused by some models in the pipeline not being converted to the correct `dtype` (`float16`) for MPS.

This commit fixes the issue by explicitly passing the `dtype` to the `pipeline.to()` method, which ensures all models in the pipeline are converted to the correct data type.