### PR TITLE
fix: Correct wav2vec dtype and silence tokenizer warning

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import psutil
 import argparse
 import gradio as gr
 import os
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
 from diffusers import FlowMatchEulerDiscreteScheduler
 from diffusers.utils import load_image
 from transformers import AutoTokenizer, Wav2Vec2Model, Wav2Vec2Processor
@@ -26,14 +27,14 @@ import shutil
 try:
     from audio_separator.separator import Separator
 except:
-    print("无法使用人声分离功能，请安装audio-separator[gpu]")
+    print("Vocal separation function is not available, please install audio-separator[gpu]")
 
 
-parser = argparse.ArgumentParser() 
-parser.add_argument("--server_name", type=str, default="127.0.0.1", help="IP地址，局域网访问改为0.0.0.0")
-parser.add_argument("--server_port", type=int, default=7891, help="使用端口")
-parser.add_argument("--share", action="store_true", help="是否启用gradio共享")
-parser.add_argument("--mcp_server", action="store_true", help="是否启用mcp服务")
+parser = argparse.ArgumentParser()
+parser.add_argument("--server_name", type=str, default="127.0.0.1", help="IP address, change to 0.0.0.0 for LAN access")
+parser.add_argument("--server_port", type=int, default=7891, help="Port to use")
+parser.add_argument("--share", action="store_true", help="Enable gradio share")
+parser.add_argument("--mcp_server", action="store_true", help="Enable mcp server")
 args = parser.parse_args()
 
 
@@ -236,11 +237,11 @@ def generate(
             output_video_with_audio
         ], check=True)
         
-    return output_video_with_audio, seed, f"Generated outputs/{timestamp}.mp4 / 已生成outputs/{timestamp}.mp4"
+    return output_video_with_audio, seed, f"Generated outputs/{timestamp}.mp4"
 
 
 def exchange_width_height(width, height):
-    return height, width, "✅ Width and Height Swapped / 宽高交换完毕"
+    return height, width, "✅ Width and Height Swapped"
 
 
 def adjust_width_height(image):
@@ -251,7 +252,7 @@ def adjust_width_height(image):
     ratio = math.sqrt(original_area / default_area)
     width = width / ratio // 16 * 16
     height = height / ratio // 16 * 16
-    return int(width), int(height), "✅ Adjusted Size Based on Image / 根据图片调整宽高"
+    return int(width), int(height), "✅ Adjusted Size Based on Image"
 
 
 def audio_extractor(video_path):
@@ -259,7 +260,7 @@ def audio_extractor(video_path):
     video = VideoFileClip(video_path)
     audio = video.audio
     audio.write_audiofile(f"outputs/{timestamp}.wav", codec='pcm_s16le')
-    return f"outputs/{timestamp}.wav", f"Generated outputs/{timestamp}.wav / 已生成outputs/{timestamp}.wav"
+    return f"outputs/{timestamp}.wav", f"Generated outputs/{timestamp}.wav"
 
 
 def vocal_separation(audio_path):
@@ -277,80 +278,9 @@ def vocal_separation(audio_path):
     destination_file = f"outputs/{timestamp}.wav"
     shutil.copy(vocal_audio_file, destination_file)
     os.remove(vocal_audio_file)
-    return f"outputs/{timestamp}.wav", f"Generated outputs/{timestamp}.wav / 已生成outputs/{timestamp}.wav"
+    return f"outputs/{timestamp}.wav", f"Generated outputs/{timestamp}.wav"
 
 
-def update_language(language):
-    if language == "English":
-        return {
-            GPU_memory_mode: gr.Dropdown(label="GPU Memory Mode", info="Normal uses 25G VRAM, model_cpu_offload uses 13G VRAM"),
-            teacache_threshold: gr.Slider(label="TeaCache Threshold", info="Recommended 0.1, 0 disables TeaCache acceleration"),
-            num_skip_start_steps: gr.Slider(label="Skip Start Steps", info="Recommended 5"),
-            clip_sample_n_frames: gr.Slider(label="Clip Sample Frames", info="Video frames, 81=2s@25fps, 161=4s@25fps, must be 4n+1"),
-            image_path: gr.Image(label="Upload Image"),
-            audio_path: gr.Audio(label="Upload Audio"),
-            prompt: gr.Textbox(label="Prompt"),
-            negative_prompt: gr.Textbox(label="Negative Prompt"),
-            generate_button: gr.Button("🎬 Start Generation"),
-            width: gr.Slider(label="Width"),
-            height: gr.Slider(label="Height"),
-            exchange_button: gr.Button("🔄 Swap Width/Height"),
-            adjust_button: gr.Button("Adjust Size Based on Image"),
-            guidance_scale: gr.Slider(label="Guidance Scale"),
-            num_inference_steps: gr.Slider(label="Sampling Steps (Recommended 50)"),
-            text_guide_scale: gr.Slider(label="Text Guidance Scale"),
-            audio_guide_scale: gr.Slider(label="Audio Guidance Scale"),
-            motion_frame: gr.Slider(label="Motion Frame"),
-            fps: gr.Slider(label="FPS"),
-            overlap_window_length: gr.Slider(label="Overlap Window Length"),
-            seed_param: gr.Number(label="Seed (positive integer, -1 for random)"),
-            info: gr.Textbox(label="Status"),
-            video_output: gr.Video(label="Generated Result"),
-            seed_output: gr.Textbox(label="Seed"),
-            video_path: gr.Video(label="Upload Video"),
-            extractor_button: gr.Button("🎬 Start Extraction"),
-            info2: gr.Textbox(label="Status"),
-            audio_output: gr.Audio(label="Generated Result"),
-            audio_path3: gr.Audio(label="Upload Audio"),
-            separation_button: gr.Button("🎬 Start Separation"),
-            info3: gr.Textbox(label="Status"),
-            audio_output3: gr.Audio(label="Generated Result")
-        }
-    else:
-        return {
-            GPU_memory_mode: gr.Dropdown(label="显存模式", info="Normal占用25G显存，model_cpu_offload占用13G显存"),
-            teacache_threshold: gr.Slider(label="teacache threshold", info="推荐参数0.1，0为禁用teacache加速"),
-            num_skip_start_steps: gr.Slider(label="跳过开始步数", info="推荐参数5"),
-            clip_sample_n_frames: gr.Slider(label="Clip采样帧数", info="视频帧数，81=2秒@25fps，161=4秒@25fps，必须为4n+1"),
-            image_path: gr.Image(label="上传图片"),
-            audio_path: gr.Audio(label="上传音频"),
-            prompt: gr.Textbox(label="提示词"),
-            negative_prompt: gr.Textbox(label="负面提示词"),
-            generate_button: gr.Button("🎬 开始生成"),
-            width: gr.Slider(label="宽度"),
-            height: gr.Slider(label="高度"),
-            exchange_button: gr.Button("🔄 交换宽高"),
-            adjust_button: gr.Button("根据图片调整宽高"),
-            guidance_scale: gr.Slider(label="guidance scale"),
-            num_inference_steps: gr.Slider(label="采样步数（推荐50步）"),
-            text_guide_scale: gr.Slider(label="text guidance scale"),
-            audio_guide_scale: gr.Slider(label="audio guidance scale"),
-            motion_frame: gr.Slider(label="motion frame"),
-            fps: gr.Slider(label="帧率"),
-            overlap_window_length: gr.Slider(label="overlap window length"),
-            seed_param: gr.Number(label="种子，请输入正整数，-1为随机"),
-            info: gr.Textbox(label="提示信息"),
-            video_output: gr.Video(label="生成结果"),
-            seed_output: gr.Textbox(label="种子"),
-            video_path: gr.Video(label="上传视频"),
-            extractor_button: gr.Button("🎬 开始提取"),
-            info2: gr.Textbox(label="提示信息"),
-            audio_output: gr.Audio(label="生成结果"),
-            audio_path3: gr.Audio(label="上传音频"),
-            separation_button: gr.Button("🎬 开始分离"),
-            info3: gr.Textbox(label="提示信息"),
-            audio_output3: gr.Audio(label="生成结果")
-        }
 
 
 with gr.Blocks(theme=gr.themes.Base()) as demo:
@@ -360,87 +290,73 @@ with gr.Blocks(theme=gr.themes.Base()) as demo:
             </div>
             """)
     
-    language_radio = gr.Radio(
-        choices=["English", "中文"], 
-        value="中文", 
-        label="Language / 语言"
-    )
-    
-    with gr.Accordion("Model Settings / 模型设置", open=False):
+    with gr.Accordion("Model Settings", open=False):
         with gr.Row():
             GPU_memory_mode = gr.Dropdown(
-                label = "显存模式", 
-                info = "Normal占用25G显存，model_cpu_offload占用13G显存", 
-                choices = ["Normal", "model_cpu_offload", "model_cpu_offload_and_qfloat8", "sequential_cpu_offload"], 
-                value = "Normal"
+                label="GPU Memory Mode",
+                info="Normal uses 25G VRAM, model_cpu_offload uses 13G VRAM",
+                choices=["Normal", "model_cpu_offload", "model_cpu_offload_and_qfloat8", "sequential_cpu_offload"],
+                value="Normal"
             )
-            teacache_threshold = gr.Slider(label="teacache threshold", info = "推荐参数0.1，0为禁用teacache加速", minimum=0, maximum=1, step=0.01, value=0)
-            num_skip_start_steps = gr.Slider(label="跳过开始步数", info = "推荐参数5", minimum=0, maximum=100, step=1, value=5)
+            teacache_threshold = gr.Slider(label="TeaCache Threshold", info="Recommended 0.1, 0 disables TeaCache acceleration", minimum=0, maximum=1, step=0.01, value=0)
+            num_skip_start_steps = gr.Slider(label="Skip Start Steps", info="Recommended 5", minimum=0, maximum=100, step=1, value=5)
         with gr.Row():
             clip_sample_n_frames = gr.Slider(
-                label="Clip Sample Frames", 
-                info="视频帧数，81=2秒@25fps，161=4秒@25fps，必须为4n+1", 
-                minimum=41, 
-                maximum=321, 
-                step=4, 
+                label="Clip Sample Frames",
+                info="Video frames, 81=2s@25fps, 161=4s@25fps, must be 4n+1",
+                minimum=41,
+                maximum=321,
+                step=4,
                 value=81
             )
     with gr.TabItem("StableAvatar"):
         with gr.Row():
             with gr.Column():
                 with gr.Row():
-                    image_path = gr.Image(label="上传图片", type="filepath", height=280)
-                    audio_path = gr.Audio(label="上传音频", type="filepath")
-                prompt = gr.Textbox(label="提示词", value="")
-                negative_prompt = gr.Textbox(label="负面提示词", value="色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走")
-                generate_button = gr.Button("🎬 开始生成", variant='primary')
-                with gr.Accordion("Parameter Settings / 参数设置", open=True):
+                    image_path = gr.Image(label="Upload Image", type="filepath", height=280)
+                    audio_path = gr.Audio(label="Upload Audio", type="filepath")
+                prompt = gr.Textbox(label="Prompt", value="")
+                negative_prompt = gr.Textbox(label="Negative Prompt", value="Colorful, overexposed, static, blurry details, subtitles, style, work, painting, picture, still, overall gray, worst quality, low quality, JPEG compression artifacts, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn face, deformed, disfigured, malformed limbs, fused fingers, still image, cluttered background, many people in the background, walking backwards")
+                generate_button = gr.Button("🎬 Start Generation", variant='primary')
+                with gr.Accordion("Parameter Settings", open=True):
                     with gr.Row():
-                        width = gr.Slider(label="宽度", minimum=256, maximum=2048, step=16, value=512)
-                        height = gr.Slider(label="高度", minimum=256, maximum=2048, step=16, value=512)
+                        width = gr.Slider(label="Width", minimum=256, maximum=2048, step=16, value=512)
+                        height = gr.Slider(label="Height", minimum=256, maximum=2048, step=16, value=512)
                     with gr.Row():
-                        exchange_button = gr.Button("🔄 交换宽高")
-                        adjust_button = gr.Button("根据图片调整宽高")
+                        exchange_button = gr.Button("🔄 Swap Width/Height")
+                        adjust_button = gr.Button("Adjust Size Based on Image")
                     with gr.Row():
-                        guidance_scale = gr.Slider(label="guidance scale", minimum=1.0, maximum=10.0, step=0.1, value=6.0)
-                        num_inference_steps = gr.Slider(label="采样步数（推荐50步）", minimum=1, maximum=100, step=1, value=10)
+                        guidance_scale = gr.Slider(label="Guidance Scale", minimum=1.0, maximum=10.0, step=0.1, value=6.0)
+                        num_inference_steps = gr.Slider(label="Sampling Steps (Recommended 50)", minimum=1, maximum=100, step=1, value=10)
                     with gr.Row():
-                        text_guide_scale = gr.Slider(label="text guidance scale", minimum=1.0, maximum=10.0, step=0.1, value=3.0)
-                        audio_guide_scale = gr.Slider(label="audio guidance scale", minimum=1.0, maximum=10.0, step=0.1, value=5.0)
+                        text_guide_scale = gr.Slider(label="Text Guidance Scale", minimum=1.0, maximum=10.0, step=0.1, value=3.0)
+                        audio_guide_scale = gr.Slider(label="Audio Guidance Scale", minimum=1.0, maximum=10.0, step=0.1, value=5.0)
                     with gr.Row():
-                        motion_frame = gr.Slider(label="motion frame", minimum=1, maximum=50, step=1, value=25)
-                        fps = gr.Slider(label="帧率", minimum=1, maximum=60, step=1, value=25)
+                        motion_frame = gr.Slider(label="Motion Frame", minimum=1, maximum=50, step=1, value=25)
+                        fps = gr.Slider(label="FPS", minimum=1, maximum=60, step=1, value=25)
                     with gr.Row():
-                        overlap_window_length = gr.Slider(label="overlap window length", minimum=1, maximum=20, step=1, value=5)
-                        seed_param = gr.Number(label="种子，请输入正整数，-1为随机", value=-1)
+                        overlap_window_length = gr.Slider(label="Overlap Window Length", minimum=1, maximum=20, step=1, value=5)
+                        seed_param = gr.Number(label="Seed (positive integer, -1 for random)", value=-1)
             with gr.Column():
-                info = gr.Textbox(label="提示信息", interactive=False)
-                video_output = gr.Video(label="生成结果", interactive=False)
-                seed_output = gr.Textbox(label="种子")
-    with gr.TabItem("Audio Extraction / 音频提取"):
+                info = gr.Textbox(label="Status", interactive=False)
+                video_output = gr.Video(label="Generated Result", interactive=False)
+                seed_output = gr.Textbox(label="Seed")
+    with gr.TabItem("Audio Extraction"):
         with gr.Row():
             with gr.Column():
-                video_path = gr.Video(label="上传视频", height=500)
-                extractor_button = gr.Button("🎬 开始提取", variant='primary')
+                video_path = gr.Video(label="Upload Video", height=500)
+                extractor_button = gr.Button("🎬 Start Extraction", variant='primary')
             with gr.Column():
-                info2 = gr.Textbox(label="提示信息", interactive=False)
-                audio_output = gr.Audio(label="生成结果", interactive=False)
-    with gr.TabItem("Vocal Separation / 人声分离"):
+                info2 = gr.Textbox(label="Status", interactive=False)
+                audio_output = gr.Audio(label="Generated Result", interactive=False)
+    with gr.TabItem("Vocal Separation"):
         with gr.Row():
             with gr.Column():
-                audio_path3 = gr.Audio(label="上传音频", type="filepath")
-                separation_button = gr.Button("🎬 开始分离", variant='primary')
+                audio_path3 = gr.Audio(label="Upload Audio", type="filepath")
+                separation_button = gr.Button("🎬 Start Separation", variant='primary')
             with gr.Column():
-                info3 = gr.Textbox(label="提示信息", interactive=False)
-                audio_output3 = gr.Audio(label="生成结果", interactive=False)
-
-    all_components = [GPU_memory_mode, teacache_threshold, num_skip_start_steps, clip_sample_n_frames, image_path, audio_path, prompt, negative_prompt, generate_button, width, height, exchange_button, adjust_button, guidance_scale, num_inference_steps, text_guide_scale, audio_guide_scale, motion_frame, fps, overlap_window_length, seed_param, info, video_output, seed_output, video_path, extractor_button, info2, audio_output, audio_path3, separation_button, info3, audio_output3]
-
-    language_radio.change(
-        fn=update_language,
-        inputs=[language_radio],
-        outputs=all_components
-    )
+                info3 = gr.Textbox(label="Status", interactive=False)
+                audio_output3 = gr.Audio(label="Generated Result", interactive=False)
 
     gr.on(
         triggers=[generate_button.click, prompt.submit, negative_prompt.submit],

--- a/wan/pipeline/wan_inference_long_pipeline.py
+++ b/wan/pipeline/wan_inference_long_pipeline.py
@@ -727,7 +727,7 @@ class WanI2VTalkingInferenceLongPipeline(DiffusionPipeline):
                     # idx_list_audio = [ii % max_audio_index for ii in range(index_start * 4 * audio_token_per_frame, index_end * 4 * audio_token_per_frame)]
                     latents = latents_all[:, :, idx_list].clone()
                     sub_vocal_input_values = vocal_input_values[idx_list_audio]
-                    sub_vocal_input_values = self.wav2vec_processor(sub_vocal_input_values, sampling_rate=sr, return_tensors="pt").input_values.to(device)
+                    sub_vocal_input_values = self.wav2vec_processor(sub_vocal_input_values, sampling_rate=sr, return_tensors="pt").input_values.to(device=device, dtype=self.wav2vec.dtype)
                     sub_vocal_embeddings = self.wav2vec(sub_vocal_input_values).last_hidden_state
                     latent_model_input = torch.cat([latents] * 3) if do_classifier_free_guidance else latents
                     if hasattr(self.scheduler, "scale_model_input"):


### PR DESCRIPTION
This commit includes two fixes:

1.  A `RuntimeError` on MPS devices caused by a `dtype` mismatch in the `wav2vec` model has been fixed. The input to the model is now explicitly cast to the model's `dtype`.

2.  A `TOKENIZERS_PARALLELISM` warning has been silenced by setting the environment variable to "false".