### PR TITLE
feat: Add MPS support and translate UI to English

### DIFF
--- a/wan/distributed/xdit_context_parallel.py
+++ b/wan/distributed/xdit_context_parallel.py
@@ -39,7 +39,7 @@ def rope_apply(x, grid_sizes, freqs):
         seq_len = f * h * w
 
         # precompute multipliers
-        x_i = torch.view_as_complex(x[i, :s].to(torch.float64).reshape(
+        x_i = torch.view_as_complex(x[i, :s].to(torch.float32).reshape(
             s, n, -1, 2))
         freqs_i = torch.cat([
             freqs[0][:f].view(f, 1, 1, -1).expand(f, h, w, -1),

--- a/wan/models/motion_controller.py
+++ b/wan/models/motion_controller.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 
 
 def sinusoidal_embedding_1d(dim, position):
-    sinusoid = torch.outer(position.type(torch.float64), torch.pow(10000, -torch.arange(dim//2, dtype=torch.float64, device=position.device).div(dim//2)))
+    sinusoid = torch.outer(position.type(torch.float32), torch.pow(10000, -torch.arange(dim//2, dtype=torch.float32, device=position.device).div(dim//2)))
     x = torch.cat([torch.cos(sinusoid), torch.sin(sinusoid)], dim=1)
     return x.to(position.dtype)
 

--- a/wan/models/wan_fantasy_transformer3d_14B.py
+++ b/wan/models/wan_fantasy_transformer3d_14B.py
@@ -208,7 +208,7 @@ def sinusoidal_embedding_1d(dim, position):
     # preprocess
     assert dim % 2 == 0
     half = dim // 2
-    position = position.type(torch.float64)
+    position = position.type(torch.float32)
 
     # calculation
     sinusoid = torch.outer(
@@ -223,7 +223,7 @@ def rope_params(max_seq_len, dim, theta=10000):
     freqs = torch.outer(
         torch.arange(max_seq_len),
         1.0 / torch.pow(theta,
-                        torch.arange(0, dim, 2).to(torch.float64).div(dim)))
+                        torch.arange(0, dim, 2).to(torch.float32).div(dim)))
     freqs = torch.polar(torch.ones_like(freqs), freqs)
     return freqs
 
@@ -266,7 +266,7 @@ def get_1d_rotary_pos_embed_riflex(
         pos = torch.from_numpy(pos)  # type: ignore  # [S]
 
     freqs = 1.0 / torch.pow(theta,
-                            torch.arange(0, dim, 2).to(torch.float64).div(dim))
+                            torch.arange(0, dim, 2).to(torch.float32).div(dim))
 
     # === Riflex modification start ===
     # Reduce the intrinsic frequency to stay within a single period after extrapolation (see Eq. (8)).

--- a/wan/models/wan_fantasy_transformer3d_1B.py
+++ b/wan/models/wan_fantasy_transformer3d_1B.py
@@ -211,7 +211,7 @@ def sinusoidal_embedding_1d(dim, position):
     # preprocess
     assert dim % 2 == 0
     half = dim // 2
-    position = position.type(torch.float64)
+    position = position.type(torch.float32)
 
     # calculation
     sinusoid = torch.outer(
@@ -226,7 +226,7 @@ def rope_params(max_seq_len, dim, theta=10000):
     freqs = torch.outer(
         torch.arange(max_seq_len),
         1.0 / torch.pow(theta,
-                        torch.arange(0, dim, 2).to(torch.float64).div(dim)))
+                        torch.arange(0, dim, 2).to(torch.float32).div(dim)))
     freqs = torch.polar(torch.ones_like(freqs), freqs)
     return freqs
 
@@ -269,7 +269,7 @@ def get_1d_rotary_pos_embed_riflex(
         pos = torch.from_numpy(pos)  # type: ignore  # [S]
 
     freqs = 1.0 / torch.pow(theta,
-                            torch.arange(0, dim, 2).to(torch.float64).div(dim))
+                            torch.arange(0, dim, 2).to(torch.float32).div(dim))
 
     # === Riflex modification start ===
     # Reduce the intrinsic frequency to stay within a single period after extrapolation (see Eq. (8)).

--- a/wan/models/wan_transformer3d.py
+++ b/wan/models/wan_transformer3d.py
@@ -207,7 +207,7 @@ def sinusoidal_embedding_1d(dim, position):
     # preprocess
     assert dim % 2 == 0
     half = dim // 2
-    position = position.type(torch.float64)
+    position = position.type(torch.float32)
 
     # calculation
     sinusoid = torch.outer(
@@ -222,7 +222,7 @@ def rope_params(max_seq_len, dim, theta=10000):
     freqs = torch.outer(
         torch.arange(max_seq_len),
         1.0 / torch.pow(theta,
-                        torch.arange(0, dim, 2).to(torch.float64).div(dim)))
+                        torch.arange(0, dim, 2).to(torch.float32).div(dim)))
     freqs = torch.polar(torch.ones_like(freqs), freqs)
     return freqs
 
@@ -264,7 +264,7 @@ def get_1d_rotary_pos_embed_riflex(
         pos = torch.from_numpy(pos)  # type: ignore  # [S]
 
     freqs = 1.0 / torch.pow(theta,
-        torch.arange(0, dim, 2).to(torch.float64).div(dim))
+                            torch.arange(0, dim, 2).to(torch.float32).div(dim))
 
     # === Riflex modification start ===
     # Reduce the intrinsic frequency to stay within a single period after extrapolation (see Eq. (8)).


### PR DESCRIPTION
This commit introduces two major updates:

1.  Full support for Apple's Metal Performance Shaders (MPS) to enable GPU acceleration on Apple Silicon devices. This includes:
    - Detecting MPS availability and setting the device and `dtype` accordingly.
    - Fixing multiple `RuntimeError` and `TypeError` exceptions related to data type mismatches (`float16`/`float32`) and unsupported `float64` operations when running on MPS.
    - Fixing a tokenizer loading path issue.
    - Silencing a `TOKENIZERS_PARALLELISM` warning.

2.  The entire Gradio application interface has been translated from Chinese to English, and the language selection feature has been removed to make the UI English-only.